### PR TITLE
Equi sized bins, fix relative path for report

### DIFF
--- a/R/loadtest_report.R
+++ b/R/loadtest_report.R
@@ -37,6 +37,9 @@ loadtest_report <- function(results, output_file=NULL){
     output_file <- file.path(getwd(),"loadtest_report.html")
     message(paste0("No output file path specified. Saving to: ",output_file))
   }
+  if(startsWith(output_file, ".")){
+    output_file <- file.path(getwd(), output_file)
+  }
 
   rmarkdown::render(system.file("report_template.Rmd", package = "loadtest"),
                     output_file = output_file,

--- a/R/loadtest_report.R
+++ b/R/loadtest_report.R
@@ -25,11 +25,12 @@
 #'
 #' @param result the output of using loadtest()
 #' @param output_file the location to save the report. Defaults to creating loadtest_report.html in the working directory.
+#' @param ... Adjust the output of rmarkdown render
 #' @examples
 #' results <- loadtest(url = "https://www.t-mobile.com", method="GET", threads = 3, loops = 5)
 #' loadtest_report(results,"~/report.html")
 #' @export
-loadtest_report <- function(results, output_file=NULL){
+loadtest_report <- function(results, output_file=NULL, ...){
   if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop("Package rmarkdown is needed for this function.",call. = FALSE)
   }
@@ -44,6 +45,7 @@ loadtest_report <- function(results, output_file=NULL){
   rmarkdown::render(system.file("report_template.Rmd", package = "loadtest"),
                     output_file = output_file,
                     intermediates_dir = dirname(output_file),
-                    params = list(results=results))
+                    params = list(results=results),
+                    ...)
 }
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -76,7 +76,7 @@ plot_elapsed_times_histogram <- function(results,binwidth=250){
 #' results <- loadtest("google.com","GET")
 #' plot_requests_per_second(results)
 #' @export
-plot_requests_per_second <- function(results){
+plot_requests_per_second <- function(results, bins = 10L){
   if (!any(c(requireNamespace("ggplot2", quietly = TRUE),
            requireNamespace("dplyr", quietly = TRUE),
            requireNamespace("tidyr", quietly = TRUE)))) {
@@ -86,17 +86,18 @@ plot_requests_per_second <- function(results){
 
   counts <- dplyr::count(results, time_since_start_rounded)
   counts <- tidyr::complete(counts, time_since_start_rounded=seq(min(time_since_start_rounded),max(time_since_start_rounded),1),fill=list(n=0))
-  counts <- dplyr::count(counts,n)
-  counts[["p"]] <- counts[["nn"]]/sum(counts[["nn"]])
-  counts <- tidyr::complete(counts, n=0:max(n),fill=list(nn=0,p=0))
-  counts[["label"]] <- paste0(round(counts[["p"]],2)*100,"%")
-  counts[["label"]] <- ifelse(counts[["nn"]] == 0, "", counts[["label"]])
+  counts[["cuts"]] <- cut(counts[["n"]], bins)
+  counts <- dplyr::count(counts, cuts)
+  counts[["p"]] <- counts[["n"]]/sum(counts[["n"]])
+  filltank <- as.factor(1L:bins); levels(filltank) <- levels(counts[["cuts"]])
+  counts <- tidyr::complete(counts, cuts = filltank, fill = list(n = 0, p = 0))
+  counts[["label"]] <- paste0(round(counts[["p"]], 2) * 100, "%")
+  counts[["label"]] <- ifelse(counts[["n"]] == 0, "", counts[["label"]])
 
-  ggplot2::ggplot(counts, ggplot2::aes(x=n,y=p,label=label))+
+  ggplot2::ggplot(counts, ggplot2::aes(x=cuts,y=p,label=label))+
     ggplot2::geom_col(fill="#E20074", color="#606060")+
     ggplot2::theme_minimal()+
     ggplot2::geom_text(vjust=-0.5)+
-    ggplot2::scale_x_continuous(breaks=seq(0,1000,1))+
     ggplot2::scale_y_continuous(limits=c(0,1),labels=function(x) paste0(round(x,2)*100,"%"))+
     ggplot2::labs(x="Requests per second",y="Percent of time at that rate",
                   title="Distribution of number of responses within a second")

--- a/R/plots.R
+++ b/R/plots.R
@@ -71,6 +71,7 @@ plot_elapsed_times_histogram <- function(results,binwidth=250){
 #' Plot the requests per second made during the test
 #'
 #' @param results A data frame returned from the loadtest function
+#' @param bins Number of equal interval bins on the plot
 #' @return A ggplot2 showing the distribution of requests by request per second
 #' @examples
 #' results <- loadtest("google.com","GET")


### PR DESCRIPTION
When benchmarking fast api, plot_requests_per_second turns into something less than readable. This commit turns the graph into a fixed number of bins splits.

Also, fix loadtest_report when providing a relative path.

Thank you for your consideration and thanks for simplifying the workflow with jmeter.